### PR TITLE
Fix branch existence logic

### DIFF
--- a/.github/workflows/chocolatey-release-tracking.yml
+++ b/.github/workflows/chocolatey-release-tracking.yml
@@ -31,7 +31,7 @@ jobs:
         id: check-placeholder-branch
         run: |
           git fetch origin
-          if git show-ref --quiet refs/heads/ci-oss-choco-package-check; then
+          if git show-ref --quiet refs/remotes/origin/ci-oss-choco-package-check; then
             echo "branch_exists=true" >> $GITHUB_OUTPUT
           else
             echo "branch_exists=false" >> $GITHUB_OUTPUT

--- a/.github/workflows/deploy-package.yml
+++ b/.github/workflows/deploy-package.yml
@@ -93,7 +93,7 @@ jobs:
   # create a placeholder branch to check if tracking branch exists for this version
   # Branch is created when package is submitted to Chocolatey
   # Branch is deleted when package becomes available on Chocolatey
-  create-placeholder-branch:
+  create_placeholder_branch_choco:
     runs-on: ubuntu-latest
     if: ${{ inputs.dry_run == true }}
     steps:
@@ -112,8 +112,8 @@ jobs:
           repository: liquibase/liquibase
           token: ${{ steps.get-token.outputs.token }} 
 
-      - name: Create placeholder branch
-        id: create-placeholder-branch
+      - name: Create placeholder branch for choco
+        id: create-placeholder-branch-choco
         run: |
           git fetch origin
           git checkout -b ci-oss-choco-package-check


### PR DESCRIPTION
This pull request updates GitHub Actions workflows related to Chocolatey package deployment and tracking. The main changes focus on improving naming consistency and fixing the branch existence check logic.

Workflow improvements and consistency:

* Renamed the job and step for creating the placeholder branch in `.github/workflows/deploy-package.yml` from `create-placeholder-branch` to `create_placeholder_branch_choco` and `create-placeholder-branch-choco` for better clarity and consistency. [[1]](diffhunk://#diff-a0f3cb0ed47d35d09a2fe19a1782484412aafbc1aa357200c8674fed6d39d2deL96-R96) [[2]](diffhunk://#diff-a0f3cb0ed47d35d09a2fe19a1782484412aafbc1aa357200c8674fed6d39d2deL115-R116)

Branch existence check fix:

* Updated the branch existence check in `.github/workflows/chocolatey-release-tracking.yml` to correctly reference `refs/remotes/origin/ci-oss-choco-package-check` instead of `refs/heads/ci-oss-choco-package-check`, ensuring the workflow checks the remote branch as intended.